### PR TITLE
Fixed disp sprintf snipped

### DIFF
--- a/Snippets/disp sprintf.tmSnippet
+++ b/Snippets/disp sprintf.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>disp(sprintf('${1:%s}\\n'${1/([^%]|%%)*(%.)?.*/(?2:, :\);)/}$2${1/([^%]|%%)*(%.)?.*/(?2:\);)/});</string>
+	<string>disp(sprintf('${1:%s}\\n'${1/([^%]|%%)*(%.)?.*/(?2:, :\))/}$2${1/([^%]|%%)*(%.)?.*/(?2:\))/});</string>
 	<key>name</key>
 	<string>disp sprintf</string>
 	<key>scope</key>


### PR DESCRIPTION
There was a semicolon after the inner sprintf command which should not have been there,
