### PR TITLE
Octave: Change "MATLAB" to "Octave" in descriptive text

### DIFF
--- a/Syntaxes/Octave.tmLanguage
+++ b/Syntaxes/Octave.tmLanguage
@@ -403,7 +403,7 @@
 		<key>constants_override</key>
 		<dict>
 			<key>comment</key>
-			<string>The user is trying to override MATLAB constants and functions.</string>
+			<string>The user is trying to override Octave constants and functions.</string>
 			<key>match</key>
 			<string>(^|\;)\s*(i|j|inf|Inf|nan|NaN|eps|end)\s*=[^=]</string>
 			<key>name</key>
@@ -487,7 +487,7 @@
 		<key>octave_constant_language</key>
 		<dict>
 			<key>comment</key>
-			<string>MATLAB constants</string>
+			<string>Octave constants</string>
 			<key>match</key>
 			<string>\b(argv|e|eps|false|F_DUPFD|F_GETFD|F_GETFL|filesep|F_SETFD|F_SETFL|i|I|inf|Inf|j|J|NA|nan|NaN|O_APPEND|O_ASYNC|O_CREAT|OCTAVE_HOME|OCTAVE_VERSION|O_EXCL|O_NONBLOCK|O_RDONLY|O_RDWR|O_SYNC|O_TRUNC|O_WRONLY|pi|program_invocation_name|program_name|P_tmpdir|realmax|realmin|SEEK_CUR|SEEK_END|SEEK_SET|SIG|stderr|stdin|stdout|true|ans|automatic_replot|beep_on_error|completion_append_char|crash_dumps_octave_core|current_script_file_name|debug_on_error|debug_on_interrupt|debug_on_warning|debug_symtab_lookups|DEFAULT_EXEC_PATH|DEFAULT_LOADPATH|default_save_format|echo_executing_commands|EDITOR|EXEC_PATH|FFTW_WISDOM_PROGRAM|fixed_point_format|gnuplot_binary|gnuplot_command_axes|gnuplot_command_end|gnuplot_command_plot|gnuplot_command_replot|gnuplot_command_splot|gnuplot_command_title|gnuplot_command_using|gnuplot_command_with|gnuplot_has_frames|history_file|history_size|ignore_function_time_stamp|IMAGEPATH|INFO_FILE|INFO_PROGRAM|__kluge_procbuf_delay__|LOADPATH|MAKEINFO_PROGRAM|max_recursion_depth|octave_core_file_format|octave_core_file_limit|octave_core_file_name|output_max_field_width|output_precision|page_output_immediately|PAGER|page_screen_output|print_answer_id_name|print_empty_dimensions|print_rhs_assign_val|PS1|PS2|PS4|save_header_format_string|save_precision|saving_history|sighup_dumps_octave_core|sigterm_dumps_octave_core|silent_functions|split_long_rows|string_fill_char|struct_levels_to_print|suppress_verbose_help_message|variables_can_hide_functions|warn_assign_as_truth_value|warn_divide_by_zero|warn_empty_list_elements|warn_fortran_indexing|warn_function_name_clash|warn_future_time_stamp|warn_imag_to_real|warn_matlab_incompatible|warn_missing_semicolon|warn_neg_dim_as_zero|warn_num_to_str|warn_precedence_change|warn_reload_forces_clear|warn_resize_on_range_error|warn_separator_insert|warn_single_quote_string|warn_str_to_num|warn_undefined_return_values|warn_variable_switch_label|whos_line_format)\b</string>
 			<key>name</key>


### PR DESCRIPTION
The Octave tmbundle is for the Octave program, which uses the M-code language and is compatible-ish with Matlab, but is not itself Matlab. How about referring to it as "Octave" instead of "MATLAB" in the descriptive text?